### PR TITLE
CI: SSL cert updates > scheduled weekly before sync-code-data

### DIFF
--- a/.github/workflows/mt-update-ssl-cert.yml
+++ b/.github/workflows/mt-update-ssl-cert.yml
@@ -2,7 +2,7 @@ name: MT update SSL cert
 on:
   workflow_dispatch: # manual
   schedule:
-    - cron: '0 18 2 * *' # Monthly on the 2nd @ 6pm UTC # WEEKLY https://crontab.guru/#0_18_2_*_*
+    - cron: '0 10 * * 2' # Tuesdays @ 12pm UTC # WEEKLY https://crontab.guru/#0_10_*_*_2
 # gh workflow run mt-update-ssl-cert.yml --ref <branch>
 # gh run list --workflow=mt-update-ssl-cert.yml
 concurrency:

--- a/.github/workflows/mt-update-ssl-cert.yml
+++ b/.github/workflows/mt-update-ssl-cert.yml
@@ -2,7 +2,7 @@ name: MT update SSL cert
 on:
   workflow_dispatch: # manual
   schedule:
-    - cron: '0 10 * * 2' # Tuesdays @ 12pm UTC # WEEKLY https://crontab.guru/#0_10_*_*_2
+    - cron: '0 10 * * 2' # Tuesdays @ 10am UTC # WEEKLY https://crontab.guru/#0_10_*_*_2
 # gh workflow run mt-update-ssl-cert.yml --ref <branch>
 # gh run list --workflow=mt-update-ssl-cert.yml
 concurrency:


### PR DESCRIPTION
In order to always release app with latest SSL cert during weekly _Sync Code & Data_, update SSL cert weekly 2 hours before.