### PR TITLE
Turn off old STM.info API for real-time status

### DIFF
--- a/app-android/src/main/res/values/stm_info_api_values.xml
+++ b/app-android/src/main/res/values/stm_info_api_values.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,UnusedResources">
-    <bool name="stm_info_api_status_provider">true</bool>
+    <bool name="stm_info_api_status_provider">false</bool><!-- using GTFS-RT trip updates instead -->
     <bool name="stm_info_api_service_update_provider">true</bool>
     <string-array name="stm_info_api_url_header_names">
         <item>apiKey</item>


### PR DESCRIPTION
Changed the status provider boolean to false to use GTFS-RT trip updates.

- https://github.com/mtransitapps/commons/pull/615